### PR TITLE
Clean Code for build/org.eclipse.pde.build

### DIFF
--- a/build/org.eclipse.pde.build/src_ant/org/eclipse/pde/internal/build/tasks/LicenseReplaceTask.java
+++ b/build/org.eclipse.pde.build/src_ant/org/eclipse/pde/internal/build/tasks/LicenseReplaceTask.java
@@ -47,7 +47,7 @@ public class LicenseReplaceTask extends Task {
 	// Path to license text
 	private String licensePath;
 
-	private class Feature {
+	private static class Feature {
 		private static final String FEATURE_START_TAG = "<feature";//$NON-NLS-1$
 		private static final String LICENSE_START_TAG = "<license"; //$NON-NLS-1$;
 		private static final String LICENSE_END_TAG = "</license>"; //$NON-NLS-1$;


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible

