### PR TITLE
Clean Code for ds/org.eclipse.pde.ds.annotations

### DIFF
--- a/ds/org.eclipse.pde.ds.annotations/src/org/eclipse/pde/ds/internal/annotations/DSAnnotationVersion.java
+++ b/ds/org.eclipse.pde.ds.annotations/src/org/eclipse/pde/ds/internal/annotations/DSAnnotationVersion.java
@@ -33,7 +33,7 @@ public enum DSAnnotationVersion {
 	public static final DSAnnotationVersion DEFAULT_VERSION = DSAnnotationVersion.V1_4;
 
 	private final String namespace;
-	private String version;
+	private final String version;
 
 	private DSAnnotationVersion(String version, String namespace) {
 		this.version = version;

--- a/ds/org.eclipse.pde.ds.annotations/src/org/eclipse/pde/ds/internal/annotations/ProjectClasspathPreferenceChangeListener.java
+++ b/ds/org.eclipse.pde.ds.annotations/src/org/eclipse/pde/ds/internal/annotations/ProjectClasspathPreferenceChangeListener.java
@@ -45,6 +45,7 @@ public class ProjectClasspathPreferenceChangeListener implements IPreferenceChan
 		ResourcesPlugin.getWorkspace().addResourceChangeListener(this, IResourceChangeEvent.PRE_CLOSE | IResourceChangeEvent.PRE_DELETE);
 	}
 
+	@Override
 	public void preferenceChange(PreferenceChangeEvent event) {
 	}
 


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible

