### PR TITLE
Clean Code for ds/org.eclipse.pde.ds.core

### DIFF
--- a/ds/org.eclipse.pde.ds.core/src/org/eclipse/pde/internal/ds/core/text/DSEntryProperties.java
+++ b/ds/org.eclipse.pde.ds.core/src/org/eclipse/pde/internal/ds/core/text/DSEntryProperties.java
@@ -28,7 +28,7 @@ import org.eclipse.pde.internal.ds.core.IDSConstants;
 public abstract class DSEntryProperties extends DSObject implements IDSBundleProperties {
 
 	private static final long serialVersionUID = 1L;
-	private int type;
+	private final int type;
 
 	public DSEntryProperties(DSModel model, String elementName, int type) {
 		super(model, elementName);

--- a/ds/org.eclipse.pde.ds.core/src/org/eclipse/pde/internal/ds/core/text/DSSingleProperty.java
+++ b/ds/org.eclipse.pde.ds.core/src/org/eclipse/pde/internal/ds/core/text/DSSingleProperty.java
@@ -22,7 +22,7 @@ import org.eclipse.pde.internal.ds.core.IDSSingleProperty;
 public abstract class DSSingleProperty extends DSObject implements IDSSingleProperty {
 
 	private static final long serialVersionUID = 1L;
-	private int type;
+	private final int type;
 
 	public DSSingleProperty(DSModel model, String element, int type) {
 		super(model, element);


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible

