### PR TITLE
Clean Code for ui/org.eclipse.pde.bnd.ui

### DIFF
--- a/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/HierarchicalLabel.java
+++ b/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/HierarchicalLabel.java
@@ -41,7 +41,7 @@ public class HierarchicalLabel<T> {
 	private static final String					DELIMITER_FOR_HIERARCHY	= " :: ";
 
 	private final List<String>					labels;
-	private Function<HierarchicalLabel<T>, T>	leafActionCallback;
+	private final Function<HierarchicalLabel<T>, T>	leafActionCallback;
 
 	boolean										enabled					= true;
 	boolean										checked					= false;

--- a/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/internal/TemplateAdapter.java
+++ b/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/internal/TemplateAdapter.java
@@ -32,7 +32,7 @@ import org.osgi.service.component.annotations.Deactivate;
 @AdapterTypes(adaptableClass = Template.class, adapterNames = { ILabelProvider.class, Image.class })
 public class TemplateAdapter implements IAdapterFactory {
 
-	private RepoTemplateLabelProvider labelProvider = new RepoTemplateLabelProvider();
+	private final RepoTemplateLabelProvider labelProvider = new RepoTemplateLabelProvider();
 	private ImageRegistry imageRegistry;
 
 	@Override

--- a/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/plugins/EclipseWorkspaceRepository.java
+++ b/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/plugins/EclipseWorkspaceRepository.java
@@ -43,7 +43,7 @@ public class EclipseWorkspaceRepository extends AbstractIndexingRepository<IProj
 
 	private static final Map<IWorkspace, EclipseWorkspaceRepository> repositoryMap = new ConcurrentHashMap<>();
 	private boolean initialized;
-	private IWorkspace workspace;
+	private final IWorkspace workspace;
 
 	EclipseWorkspaceRepository(IWorkspace workspace) {
 		this.workspace = workspace;

--- a/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/preferences/BndPreferences.java
+++ b/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/preferences/BndPreferences.java
@@ -87,7 +87,7 @@ public class BndPreferences {
 	private static final boolean DEFAULT_PREF_EDITOR_OPEN_SOURCE_TAB = false;
 
 	private final IPreferenceStore	store;
-	private IProject project;
+	private final IProject project;
 
 	public BndPreferences(IProject project, IPreferenceStore store) {
 		this.store = store;

--- a/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/views/ViewEventTopics.java
+++ b/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/views/ViewEventTopics.java
@@ -25,7 +25,7 @@ public enum ViewEventTopics {
 	 */
 	REPOSITORIESVIEW_OPEN_ADVANCED_SEARCH("EVENT/RepositoriesView/openAdvancedSearch");
 
-	private String eventtype;
+	private final String eventtype;
 
 	ViewEventTopics(String eventtype) {
 		this.eventtype = eventtype;

--- a/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/views/repository/RepositoriesView.java
+++ b/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/views/repository/RepositoriesView.java
@@ -195,8 +195,8 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 
 	private Workspace workspace;
 	
-	private IObservableValue<String> workspaceName = new WritableValue<>();
-	private IObservableValue<String> workspaceDescription = new WritableValue<>();
+	private final IObservableValue<String> workspaceName = new WritableValue<>();
+	private final IObservableValue<String> workspaceDescription = new WritableValue<>();
 
 	@Override
 	public void createPartControl(final Composite parent) {

--- a/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/wizards/AddFilesToRepositoryWizard.java
+++ b/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/wizards/AddFilesToRepositoryWizard.java
@@ -55,7 +55,7 @@ public class AddFilesToRepositoryWizard extends Wizard {
 
 	private final LocalRepositorySelectionPage		repoSelectionPage;
 	private final AddFilesToRepositoryWizardPage	fileSelectionPage;
-	private Workspace workspace;
+	private final Workspace workspace;
 
 	public AddFilesToRepositoryWizard(Workspace workspace, RepositoryPlugin repository, File[] initialFiles) {
 		this.workspace = workspace;

--- a/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/wizards/LocalRepositorySelectionPage.java
+++ b/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/bnd/ui/wizards/LocalRepositorySelectionPage.java
@@ -46,7 +46,7 @@ class LocalRepositorySelectionPage extends WizardPage {
 	private final PropertyChangeSupport	propSupport			= new PropertyChangeSupport(this);
 	private RepositoryPlugin			selectedRepository	= null;
 
-	private Workspace workspace;
+	private final Workspace workspace;
 
 	LocalRepositorySelectionPage(Workspace workspace, String pageName) {
 		this(workspace, pageName, null);

--- a/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/osgi/xmlns/metatype/v1_4/Tad.java
+++ b/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/osgi/xmlns/metatype/v1_4/Tad.java
@@ -86,7 +86,7 @@ public class Tad {
     @XmlAttribute(name = "required")
     protected Boolean required;
     @XmlAnyAttribute
-    private Map<QName, String> otherAttributes = new HashMap<QName, String>();
+    private final Map<QName, String> otherAttributes = new HashMap<QName, String>();
 
     /**
      * Gets the value of the optionOrAny property.

--- a/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/osgi/xmlns/metatype/v1_4/Tattribute.java
+++ b/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/osgi/xmlns/metatype/v1_4/Tattribute.java
@@ -65,7 +65,7 @@ public class Tattribute {
     @XmlAttribute(name = "content")
     protected String content;
     @XmlAnyAttribute
-    private Map<QName, String> otherAttributes = new HashMap<QName, String>();
+    private final Map<QName, String> otherAttributes = new HashMap<QName, String>();
 
     /**
      * Gets the value of the valueOrAny property.

--- a/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/osgi/xmlns/metatype/v1_4/Tdesignate.java
+++ b/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/osgi/xmlns/metatype/v1_4/Tdesignate.java
@@ -75,7 +75,7 @@ public class Tdesignate {
     @XmlAttribute(name = "merge")
     protected Boolean merge;
     @XmlAnyAttribute
-    private Map<QName, String> otherAttributes = new HashMap<QName, String>();
+    private final Map<QName, String> otherAttributes = new HashMap<QName, String>();
 
     /**
      * Ruft den Wert der object-Eigenschaft ab.

--- a/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/osgi/xmlns/metatype/v1_4/Ticon.java
+++ b/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/osgi/xmlns/metatype/v1_4/Ticon.java
@@ -64,7 +64,7 @@ public class Ticon {
     @XmlSchemaType(name = "positiveInteger")
     protected BigInteger size;
     @XmlAnyAttribute
-    private Map<QName, String> otherAttributes = new HashMap<QName, String>();
+    private final Map<QName, String> otherAttributes = new HashMap<QName, String>();
 
     /**
      * Gets the value of the any property.

--- a/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/osgi/xmlns/metatype/v1_4/Tmetadata.java
+++ b/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/osgi/xmlns/metatype/v1_4/Tmetadata.java
@@ -67,7 +67,7 @@ public class Tmetadata {
     @XmlAttribute(name = "localization")
     protected String localization;
     @XmlAnyAttribute
-    private Map<QName, String> otherAttributes = new HashMap<QName, String>();
+    private final Map<QName, String> otherAttributes = new HashMap<QName, String>();
 
     /**
      * Gets the value of the ocdOrDesignateOrAny property.

--- a/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/osgi/xmlns/metatype/v1_4/Tobject.java
+++ b/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/osgi/xmlns/metatype/v1_4/Tobject.java
@@ -62,7 +62,7 @@ public class Tobject {
     @XmlAttribute(name = "ocdref", required = true)
     protected String ocdref;
     @XmlAnyAttribute
-    private Map<QName, String> otherAttributes = new HashMap<QName, String>();
+    private final Map<QName, String> otherAttributes = new HashMap<QName, String>();
 
     /**
      * Gets the value of the attributeOrAny property.

--- a/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/osgi/xmlns/metatype/v1_4/Tocd.java
+++ b/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/osgi/xmlns/metatype/v1_4/Tocd.java
@@ -73,7 +73,7 @@ public class Tocd {
     @XmlAttribute(name = "id", required = true)
     protected String id;
     @XmlAnyAttribute
-    private Map<QName, String> otherAttributes = new HashMap<QName, String>();
+    private final Map<QName, String> otherAttributes = new HashMap<QName, String>();
 
     /**
      * Gets the value of the adOrIconOrAny property.

--- a/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/osgi/xmlns/metatype/v1_4/Toption.java
+++ b/ui/org.eclipse.pde.bnd.ui/src/org/eclipse/pde/osgi/xmlns/metatype/v1_4/Toption.java
@@ -61,7 +61,7 @@ public class Toption {
     @XmlAttribute(name = "value", required = true)
     protected String value;
     @XmlAnyAttribute
-    private Map<QName, String> otherAttributes = new HashMap<QName, String>();
+    private final Map<QName, String> otherAttributes = new HashMap<QName, String>();
 
     /**
      * Gets the value of the any property.


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible

