### PR TITLE
Clean Code for ui/org.eclipse.pde.core

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/annotations/OSGiAnnotationsClasspathContributor.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/annotations/OSGiAnnotationsClasspathContributor.java
@@ -54,7 +54,7 @@ public class OSGiAnnotationsClasspathContributor implements IClasspathContributo
 			"org.osgi.annotation.bundle", "org.osgi.service.component.annotations", //$NON-NLS-1$ //$NON-NLS-2$
 			"org.osgi.service.metatype.annotations"); //$NON-NLS-1$
 
-	private ConcurrentMap<String, Collection<IClasspathEntry>> entryMap = new ConcurrentHashMap<>();
+	private final ConcurrentMap<String, Collection<IClasspathEntry>> entryMap = new ConcurrentHashMap<>();
 
 	@Override
 	public List<IClasspathEntry> getInitialEntries(BundleDescription project) {

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/DelegateRepositoryListener.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/DelegateRepositoryListener.java
@@ -23,7 +23,7 @@ import aQute.bnd.service.RepositoryPlugin;
 
 public class DelegateRepositoryListener implements RepositoryListenerPlugin {
 
-	private Supplier<Stream<RepositoryListenerPlugin>> delegateSupplier;
+	private final Supplier<Stream<RepositoryListenerPlugin>> delegateSupplier;
 
 	public DelegateRepositoryListener(Supplier<Stream<RepositoryListenerPlugin>> delegateSupplier) {
 		this.delegateSupplier = delegateSupplier;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/SupplierClipboard.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/SupplierClipboard.java
@@ -20,7 +20,7 @@ import aQute.bnd.service.clipboard.Clipboard;
 
 public class SupplierClipboard implements Clipboard {
 
-	private Supplier<Clipboard> supplier;
+	private final Supplier<Clipboard> supplier;
 
 	public SupplierClipboard(Supplier<Clipboard> supplier) {
 		this.supplier = supplier;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/TargetRepository.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/bnd/TargetRepository.java
@@ -238,8 +238,8 @@ public class TargetRepository extends BaseRepository implements RepositoryPlugin
 
 	private static final class BundleDescriptionRepositoryResource implements RepositoryContent, Resource, IAdaptable {
 
-		private BundleDescription bundle;
-		private Repository repository;
+		private final BundleDescription bundle;
+		private final Repository repository;
 
 		public BundleDescriptionRepositoryResource(Repository repository, BundleDescription bundle) {
 			this.repository = repository;
@@ -346,7 +346,7 @@ public class TargetRepository extends BaseRepository implements RepositoryPlugin
 		private Capability capability;
 		private long lastLength;
 		private long lastModified;
-		private Resource resource;
+		private final Resource resource;
 
 		public ContentCapabilityCache(File file, Resource resource) {
 			this.file = file;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/schema/PathSchemaProvider.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/schema/PathSchemaProvider.java
@@ -24,7 +24,7 @@ import org.eclipse.pde.internal.core.ischema.ISchemaDescriptor;
 
 public class PathSchemaProvider implements SchemaProvider {
 
-	private List<IPath> searchPath;
+	private final List<IPath> searchPath;
 
 	public PathSchemaProvider(List<IPath> searchPath) {
 		this.searchPath = searchPath;

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/schema/SchemaToHTMLConverter.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/schema/SchemaToHTMLConverter.java
@@ -57,8 +57,8 @@ import org.xml.sax.SAXException;
 public class SchemaToHTMLConverter {
 
 	private final SchemaTransformer fTransformer = new SchemaTransformer();
-	private File baseDir;
-	private URL cssURL;
+	private final File baseDir;
+	private final URL cssURL;
 
 	public SchemaToHTMLConverter(File baseDir, URL cssURL) {
 		this.baseDir = baseDir;


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible

