### PR TITLE
Clean Code for ui/org.eclipse.pde.genericeditor.extension

### DIFF
--- a/ui/org.eclipse.pde.genericeditor.extension/src/org/eclipse/pde/internal/genericeditor/target/extension/model/LocationNode.java
+++ b/ui/org.eclipse.pde.genericeditor.extension/src/org/eclipse/pde/internal/genericeditor/target/extension/model/LocationNode.java
@@ -22,7 +22,7 @@ import java.util.List;
  */
 public class LocationNode extends Node {
 
-	private List<String> repositoryLocations = new ArrayList<>();
+	private final List<String> repositoryLocations = new ArrayList<>();
 
 	public List<String> getRepositoryLocations() {
 		return repositoryLocations;


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible

