### PR TITLE
Clean Code for ui/org.eclipse.pde.spy.preferences

### DIFF
--- a/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/handler/ShowAllPreferencesHandler.java
+++ b/ui/org.eclipse.pde.spy.preferences/src/org/eclipse/pde/spy/preferences/handler/ShowAllPreferencesHandler.java
@@ -52,7 +52,7 @@ public class ShowAllPreferencesHandler {
 		eventBroker.post(PreferenceSpyEventTopics.PREFERENCESPY_PREFERENCE_SHOW, preferenceEntries.values());
 	}
 
-	private class PrefereneGatherer implements IPreferenceNodeVisitor {
+	private static class PrefereneGatherer implements IPreferenceNodeVisitor {
 
 		private final Map<String, PreferenceNodeEntry> preferenceEntries;
 


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible

