### PR TITLE
Clean Code for ui/org.eclipse.pde.ui

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/bndtools/BndScanner.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/bndtools/BndScanner.java
@@ -40,12 +40,12 @@ import aQute.bnd.osgi.Constants;
 public class BndScanner extends RuleBasedScanner {
 	final Set<String>				instructions;
 	final Set<String>				directives	= new HashSet<>();
-	private Token T_DEFAULT;
-	private Token T_KEY;
-	private Token T_ERROR;
-	private Token T_COMMENT;
-	private Token T_INSTRUCTION;
-	private Token T_OPTION;
+	private final Token T_DEFAULT;
+	private final Token T_KEY;
+	private final Token T_ERROR;
+	private final Token T_COMMENT;
+	private final Token T_INSTRUCTION;
+	private final Token T_OPTION;
 
 	public BndScanner(IColorManager colorManager) {
 		T_DEFAULT = new Token(new TextAttribute(colorManager.getColor(IJavaColorConstants.JAVA_DEFAULT)));

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/java/AddPdeClasspathContainerClasspathFixProposal.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/java/AddPdeClasspathContainerClasspathFixProposal.java
@@ -26,7 +26,7 @@ import org.eclipse.swt.graphics.Image;
 
 public class AddPdeClasspathContainerClasspathFixProposal extends ClasspathFixProposal {
 
-	private IJavaProject project;
+	private final IJavaProject project;
 
 	public AddPdeClasspathContainerClasspathFixProposal(IJavaProject project) {
 		this.project = project;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/JavaAttributeWizardPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/editor/plugin/JavaAttributeWizardPage.java
@@ -44,7 +44,7 @@ public class JavaAttributeWizardPage extends NewClassWizardPage {
 	private final ISchemaAttribute attInfo;
 	private final IPluginModelBase model;
 	private final InitialClassProperties initialValues;
-	private IJavaProject javaProject;
+	private final IJavaProject javaProject;
 
 	static class InitialClassProperties {
 		// populate new wizard page

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/parts/PluginVersionPart.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/parts/PluginVersionPart.java
@@ -179,7 +179,7 @@ public class PluginVersionPart {
 	private VersionRange fVersionRange;
 	private boolean fIsRanged;
 	private final boolean fRangeAllowed;
-	private boolean isPlugin;
+	private final boolean isPlugin;
 
 	public PluginVersionPart(boolean rangeAllowed) {
 		this(rangeAllowed, false);

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/RepositoryBundleContainerAdapterFactory.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/RepositoryBundleContainerAdapterFactory.java
@@ -117,10 +117,12 @@ public class RepositoryBundleContainerAdapterFactory implements IAdapterFactory 
 			return segment instanceof RepositoryBundleContainer || segment instanceof RequirementNode;
 		}
 
+		@Override
 		public boolean canRemove(ITargetDefinition target, TreePath treePath) {
 			return treePath.getLastSegment() instanceof RequirementNode;
 		}
 
+		@Override
 		public IStatus remove(ITargetDefinition target, TreePath[] treePaths) {
 			boolean reload = false;
 			for (TreePath path : treePaths) {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/UpdateTargetJob.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/shared/target/UpdateTargetJob.java
@@ -39,9 +39,9 @@ public class UpdateTargetJob extends Job {
 
 	private final IJobFunction action;
 
-	private boolean update;
+	private final boolean update;
 
-	private Job cancelJob;
+	private final Job cancelJob;
 
 	/**
 	 * Schedules a new update job that will update all selected children of the

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/plugin/TemplateListSelectionPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/plugin/TemplateListSelectionPage.java
@@ -57,7 +57,7 @@ public class TemplateListSelectionPage extends WizardListSelectionPage {
 	private final ContentPage fContentPage;
 	private Button fUseTemplate;
 	private String fInitialTemplateId;
-	private Map<Template, CompletableFuture<String>> templateTextLoadings = new HashMap<>();
+	private final Map<Template, CompletableFuture<String>> templateTextLoadings = new HashMap<>();
 
 	class WizardFilter extends ViewerFilter {
 		@Override

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/plugin/TemplatePluginContentWizard.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/plugin/TemplatePluginContentWizard.java
@@ -45,7 +45,7 @@ import aQute.bnd.build.model.EE;
 public class TemplatePluginContentWizard extends Wizard implements IPluginContentWizard {
 
 	private static final String DEFAULT_BND_INSTRUCTION = "bnd.bnd"; //$NON-NLS-1$
-	private Template template;
+	private final Template template;
 	private IFieldData data;
 	private TemplateParamsWizardPage paramsWizardPage;
 

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/ConvertAutomaticManifestProcessor.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/ConvertAutomaticManifestProcessor.java
@@ -56,7 +56,7 @@ import org.osgi.framework.Version;
 
 public class ConvertAutomaticManifestProcessor extends RefactoringProcessor {
 
-	private List<IProject> projects;
+	private final List<IProject> projects;
 	private boolean useProjectRoot;
 	private boolean keepRequireBundle;
 	private boolean keepImportPackage;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/ConvertAutomaticManifestsWizardSettingsPage.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/ConvertAutomaticManifestsWizardSettingsPage.java
@@ -32,7 +32,7 @@ public class ConvertAutomaticManifestsWizardSettingsPage extends UserInputWizard
 	private static final String KEY_KEEP_IMPORT_PACKAGE = "keep_import_package"; //$NON-NLS-1$
 	private static final String KEY_KEEP_EXPORT_PACKAGE = "keep_export_package"; //$NON-NLS-1$
 	private static final String KEY_KEEP_REQUIREDEXECUTIONENVIRONMENT = "keep_requiredexecutionenvironment_package"; //$NON-NLS-1$
-	private ConvertAutomaticManifestProcessor processor;
+	private final ConvertAutomaticManifestProcessor processor;
 
 	public ConvertAutomaticManifestsWizardSettingsPage(ConvertAutomaticManifestProcessor processor) {
 		super(PDEUIMessages.ConvertAutomaticManifestWizardPage_title);

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/change/BndProjectUpdateChange.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/change/BndProjectUpdateChange.java
@@ -32,7 +32,7 @@ import org.eclipse.pde.internal.ui.PDEUIMessages;
 
 public final class BndProjectUpdateChange extends Change {
 
-	private IProject project;
+	private final IProject project;
 
 	public BndProjectUpdateChange(IProject project) {
 		this.project = project;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/change/BuildToBndChange.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/change/BuildToBndChange.java
@@ -54,9 +54,9 @@ public class BuildToBndChange extends Change {
 
 	@SuppressWarnings("restriction")
 	private static final String DS_CONTENT_TYPE_ID = org.eclipse.pde.internal.ds.core.Activator.CONTENT_TYPE_ID;
-	private IBuildModel model;
-	private IProject project;
-	private IFile instructionfile;
+	private final IBuildModel model;
+	private final IProject project;
+	private final IFile instructionfile;
 
 	public BuildToBndChange(IProject project, IBuildModel model, IFile instructionfile) {
 		this.project = project;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/change/CreatePackageInfoChange.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/change/CreatePackageInfoChange.java
@@ -31,11 +31,11 @@ public class CreatePackageInfoChange extends ResourceChange {
 
 	public static final String PACKAGE_INFO_JAVA = org.eclipse.jdt.internal.corext.util.JavaModelUtil.PACKAGE_INFO_JAVA;
 
-	private IPackageFragment fragment;
+	private final IPackageFragment fragment;
 
-	private String name;
+	private final String name;
 
-	private Version version;
+	private final Version version;
 
 	public CreatePackageInfoChange(IPackageFragment fragment, String name, Version version) {
 		this.fragment = fragment;

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/change/ManifestToBndChange.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/change/ManifestToBndChange.java
@@ -43,13 +43,13 @@ import aQute.bnd.properties.Document;
 
 public class ManifestToBndChange extends Change {
 
-	private IFile manifestFile;
-	private IPluginModelBase model;
-	private boolean keepRequireBundle;
-	private boolean keepImportPackage;
-	private boolean keepBREE;
-	private boolean keepExportPackage;
-	private IFile instructionFile;
+	private final IFile manifestFile;
+	private final IPluginModelBase model;
+	private final boolean keepRequireBundle;
+	private final boolean keepImportPackage;
+	private final boolean keepBREE;
+	private final boolean keepExportPackage;
+	private final IFile instructionFile;
 
 	public ManifestToBndChange(IProject project, IFile manifest, IPluginModelBase model, IFile instructionsFile,
 			boolean keepRequireBundle,

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/change/PreferenceChange.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/wizards/tools/change/PreferenceChange.java
@@ -27,7 +27,7 @@ import org.osgi.service.prefs.BackingStoreException;
 
 public class PreferenceChange extends Change {
 
-	private IEclipsePreferences node;
+	private final IEclipsePreferences node;
 
 	public PreferenceChange(IEclipsePreferences node) {
 		this.node = node;


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible

