### PR TITLE
Clean Code for ui/org.eclipse.tools.layout.spy

### DIFF
--- a/ui/org.eclipse.tools.layout.spy/src/org/eclipse/tools/layout/spy/internal/dialogs/LayoutSpyDialog.java
+++ b/ui/org.eclipse.tools.layout.spy/src/org/eclipse/tools/layout/spy/internal/dialogs/LayoutSpyDialog.java
@@ -103,7 +103,7 @@ public class LayoutSpyDialog {
 	private Text diagnostics;
 	private Button showColoringButton;
 
-	private class LayoutSpyLabelProvider extends ColumnLabelProvider {
+	private static class LayoutSpyLabelProvider extends ColumnLabelProvider {
 		@Override
 		public Color getForeground(Object element) {
 			Control child = (Control) element;


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible

